### PR TITLE
Update README.md for 'tessellation-with-image-texture' example

### DIFF
--- a/models/tessellated-shape-with-style/tessellation-with-image-texture/README.md
+++ b/models/tessellated-shape-with-style/tessellation-with-image-texture/README.md
@@ -1,6 +1,6 @@
 ﻿The tessellated shape representation includes an indexed texture coordinate list, providing texture vertices for each face, along with a texture referenced by URL. Figure 483 shows a cylinder with faces having specific texture coordinates.
 
-![SurfaceTexture](../../figures/examples/tessellation_texture_image.png)
+![SurfaceTexture](../../figures/examples/texture.png)
 
 Figure 483 — Tessellation with textures
 


### PR DESCRIPTION
Update README.md for 'tessellation-with-image-texture example', with the correcth path of the texture (see https://github.com/buildingSMART/IFC4.3.x-development/compare/master...Baruchware:IFC4.3.x-development:master?expand=1)