### PR TITLE
Add extra check for invalid UTF-8 BOM of IFC files

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,8 @@ jobs:
         unzip ifcopenshell-python-311-v0.7.0-f7c03db-linux64.zip -d ~/.local/lib/python3.11/site-packages
         git clone --depth 1 https://github.com/IfcOpenShell/step-file-parser
         pip install --user -r ./step-file-parser/requirements.in
+    - name: Check for UTF-8 BOM
+      run: "! find ./models -name '*.ifc' -print0 | xargs -0 grep -l $'^\\xEF\\xBB\\xBF' | grep ."
     - name: Validate IFC example files
       run: |
         valid_count=0


### PR DESCRIPTION
If step file validation fails due to unexpected UTF-8 BOM, this extra check can reveal it more expressively.